### PR TITLE
Fixes incorrect codecov results.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@
  *  License for the specific language governing permissions and limitations
  *  under the License.
  */
- 
+
 const webpackConfig = require('./webpack.config.js');
 
 module.exports = function(config) {
@@ -28,19 +28,18 @@ module.exports = function(config) {
       },
     },
     coverageReporter: {
+      dir: 'coverage',
       reporters: [{
+        type: 'text'
+      }, {
         type: 'lcov'
       }]
     },
     files: [
-      'src/**/__tests__/**',
-    ],
-    exclude: [
-      '**/*.map',
+      'src/**/__tests__/*.ts',
     ],
     preprocessors: {
-      './src/**/*.ts': ['webpack', 'coverage'],
-      './src/**/*.js': ['webpack', 'coverage'],
+      'src/**/*.ts': ['webpack'],
     },
     webpack: {
       devtool: webpackConfig.devtool,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^0.26.0",
     "del-cli": "^0.2.0",
     "html-loader": "^0.4.4",
+    "istanbul-instrumenter-loader": "^1.1.0",
     "karma": "^1.3.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,6 @@
   "include": [
     "./src/**/*"
   ],
-  "exclude": [
-    "**/*_test.ts"
-  ],
   "compileOnSave": false,
   "buildOnSave": false
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,11 @@ module.exports = {
     }, {
       test: /\.html$/,
       loader: 'html-loader'
+    }, {
+      test: /\.tsx?$/,
+      exclude: /(__tests__|node_modules)\//,
+      loader: 'istanbul-instrumenter-loader',
+      enforce: 'post'
     }],
   },
   externals: {


### PR DESCRIPTION
Karma was incorrectly including tests only in coverage report. Fixed by adding a postLoader in webpack to run istanbul coverage only on non-test `src` files.